### PR TITLE
Implement story 3.8 contacts facets backend

### DIFF
--- a/yorindo-api/openapi.yaml
+++ b/yorindo-api/openapi.yaml
@@ -2095,6 +2095,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/ApiError'
 
+  /contacts/facets:
+    get:
+      summary: Get contact filter facets with counts
+      operationId: getContactFacets
+      tags: [Contacts]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Contact facets for filter dropdowns
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ContactFacets'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
   /contacts/industry-suggestions:
     get:
       summary: Suggest canonical industry slugs from free-form text

--- a/yorindo-api/src/routes/contacts.routes.ts
+++ b/yorindo-api/src/routes/contacts.routes.ts
@@ -116,6 +116,29 @@ function toSortBy(sortBy?: string): string | undefined {
 }
 
 /**
+ * Mengubah hasil facet repository ke shape slug/label/count yang dipakai FE.
+ */
+function toFacetsDto(facets: Awaited<ReturnType<typeof contactRepository.findFacets>>) {
+  return {
+    industry: facets.industries.map((item) => ({
+      slug: toIndustrySlug(item.id),
+      label: item.name,
+      count: item.count,
+    })),
+    city: facets.cities.map((item) => ({
+      slug: item.city.toLowerCase(),
+      label: item.city,
+      count: item.count,
+    })),
+    companySize: facets.companySizes.map((item) => ({
+      slug: toApiCompanySize(item.size as Contact['companySize']),
+      label: toApiCompanySize(item.size as Contact['companySize']).replace(/^./, (value) => value.toUpperCase()),
+      count: item.count,
+    })),
+  }
+}
+
+/**
  * Membentuk DTO kontak agar kontrak respons lebih cocok dengan kebutuhan FE.
  */
 function toContactDto(contact: Contact) {
@@ -161,6 +184,12 @@ export const contactRoutes: FastifyPluginAsync = async (fastify) => {
       missingPhone: health.missingPhone,
     }
     validateOpenApiResponse({ path: '/contacts/health', method: 'get', status: 200, body: responseBody })
+    return reply.status(200).send(responseBody)
+  })
+
+  fastify.get('/api/contacts/facets', async (_request, reply) => {
+    const responseBody = toFacetsDto(await contactRepository.findFacets())
+    validateOpenApiResponse({ path: '/contacts/facets', method: 'get', status: 200, body: responseBody })
     return reply.status(200).send(responseBody)
   })
 

--- a/yorindo-api/src/tests/contacts.routes.test.ts
+++ b/yorindo-api/src/tests/contacts.routes.test.ts
@@ -31,6 +31,38 @@ describe('GET /api/contacts/health', () => {
   })
 })
 
+describe('GET /api/contacts/facets', () => {
+  it('returns filter facets with slug, label, and count', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/contacts/facets',
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.industry).toBeInstanceOf(Array)
+    expect(body.city).toBeInstanceOf(Array)
+    expect(body.companySize).toBeInstanceOf(Array)
+    expect(body.industry[0]).toMatchObject({
+      slug: expect.any(String),
+      label: expect.any(String),
+      count: expect.any(Number),
+    })
+    expect(body.city[0]).toMatchObject({
+      slug: expect.any(String),
+      label: expect.any(String),
+      count: expect.any(Number),
+    })
+    expect(body.companySize[0]).toMatchObject({
+      slug: expect.any(String),
+      label: expect.any(String),
+      count: expect.any(Number),
+    })
+    expect(body.city.reduce((sum: number, item: { count: number }) => sum + item.count, 0)).toBe(120)
+    expect(body.companySize.reduce((sum: number, item: { count: number }) => sum + item.count, 0)).toBe(120)
+  })
+})
+
 describe('GET /api/contacts', () => {
   it('returns paginated contacts with default page size', async () => {
     const res = await app.inject({


### PR DESCRIPTION
## Summary
- implement backend endpoint `GET /api/contacts/facets`
- add OpenAPI contract for contact facets
- add route coverage for facets response

## Verification
- `npm test -- src/tests/contacts.routes.test.ts`
- `npx tsc --noEmit`