### PR TITLE
Implement story 3.11 upcoming uncontacted event backend

### DIFF
--- a/yorindo-api/openapi.yaml
+++ b/yorindo-api/openapi.yaml
@@ -1628,6 +1628,7 @@ components:
       properties:
         event:
           type: object
+          nullable: true
           required: [id, name, eventDate]
           properties:
             id:
@@ -2069,6 +2070,27 @@ paths:
                 $ref: '#/components/schemas/ApiError'
         '404':
           description: Contact not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ApiError'
+
+  /events/upcoming-uncontacted:
+    get:
+      summary: Get the next event within 14 days with uncontacted audience
+      operationId: getUpcomingUncontactedEvent
+      tags: [Events]
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Upcoming event banner payload
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpcomingUncontactedResponse'
+        '401':
+          description: Unauthorized
           content:
             application/json:
               schema:

--- a/yorindo-api/src/repositories/memory/EventRepository.ts
+++ b/yorindo-api/src/repositories/memory/EventRepository.ts
@@ -162,9 +162,13 @@ export class InMemoryEventRepository implements IEventRepository {
   }
 
   async getUpcomingUncontacted(): Promise<UpcomingUncontactedResult | null> {
-    const upcoming = Array.from(this.events.values()).find(
-      e => e.status === 'published' && new Date(e.date) > new Date()
-    )
+    const upcoming = Array.from(this.events.values())
+      .filter((event) => {
+        if (!['published', 'active'].includes(event.status)) return false
+        const daysTill = Math.floor((new Date(event.date).getTime() - Date.now()) / 86400000)
+        return daysTill >= 0 && daysTill <= 14
+      })
+      .sort((left, right) => new Date(left.date).getTime() - new Date(right.date).getTime())[0]
     if (!upcoming) return null
     const daysTill = Math.floor((new Date(upcoming.date).getTime() - Date.now()) / 86400000)
     return { eventId: upcoming.id, eventName: upcoming.name, daysTillEvent: daysTill, uncontactedCount: 42 }

--- a/yorindo-api/src/routes/events.routes.ts
+++ b/yorindo-api/src/routes/events.routes.ts
@@ -13,6 +13,7 @@ import {
 import { requireAdmin, requireAuth, requireRoles, type JwtPayload } from '../middleware/auth.js'
 import type { Event, Registration } from '../types/domain.js'
 import { validateOpenApiRequest, validateOpenApiResponse } from '../lib/openapi-contract.js'
+import { INDONESIAN_INDUSTRIES } from '../repositories/memory/_seeds.js'
 
 const EventIdParamsSchema = z.object({
   id: z.string().trim().min(1),
@@ -180,6 +181,16 @@ function toRegistrationWithContactDto(registration: Registration, contact: Await
   }
 }
 
+/**
+ * Mengubah daftar industry id event ke slug FE agar URL blast tetap bersih.
+ */
+function toIndustryTags(event: Event | null): string[] {
+  return (event?.targetCriteria?.industries ?? []).map((industryId) => {
+    const found = INDONESIAN_INDUSTRIES.find((item) => item.id === industryId || item.slug === industryId)
+    return found?.slug ?? industryId
+  })
+}
+
 async function requireEventOr404(reply: FastifyReply, eventId: string) {
   const event = await eventRepository.findById(eventId)
   if (!event) {
@@ -247,6 +258,31 @@ export const eventsRoutes: FastifyPluginAsync = async (fastify) => {
       },
     }
     validateOpenApiResponse({ path: '/events', method: 'get', status: 200, body: responseBody })
+    return reply.status(200).send(responseBody)
+  })
+
+  fastify.get('/api/events/upcoming-uncontacted', { preHandler: requireAuth }, async (_request, reply) => {
+    const upcoming = await eventRepository.getUpcomingUncontacted()
+
+    const event = upcoming ? await eventRepository.findById(upcoming.eventId) : null
+    const responseBody = upcoming && event
+      ? {
+          event: {
+            id: event.id,
+            name: event.name,
+            eventDate: event.date,
+            industryTags: toIndustryTags(event),
+          },
+          daysUntil: upcoming.daysTillEvent,
+          uncontactedCount: upcoming.uncontactedCount,
+        }
+      : {
+          event: null,
+          daysUntil: 0,
+          uncontactedCount: 0,
+        }
+
+    validateOpenApiResponse({ path: '/events/upcoming-uncontacted', method: 'get', status: 200, body: responseBody })
     return reply.status(200).send(responseBody)
   })
 

--- a/yorindo-api/src/tests/events.routes.test.ts
+++ b/yorindo-api/src/tests/events.routes.test.ts
@@ -1,0 +1,57 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import type { FastifyInstance } from 'fastify'
+import { buildServer } from '../server.js'
+
+let app: FastifyInstance
+let adminToken = ''
+
+beforeAll(async () => {
+  process.env.JWT_SECRET = 'test-secret-at-least-32-characters-long'
+  process.env.JWT_REFRESH_SECRET = 'test-refresh-secret-at-least-32-characters-long'
+  app = await buildServer()
+  await app.ready()
+
+  const login = await app.inject({
+    method: 'POST',
+    url: '/api/auth/login',
+    payload: { email: 'admin@yorindo.id', password: 'Password123!' },
+  })
+  adminToken = login.json().accessToken
+})
+
+afterAll(async () => {
+  await app.close()
+})
+
+describe('GET /api/events/upcoming-uncontacted', () => {
+  it('returns the upcoming event banner payload for authenticated admin', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/events/upcoming-uncontacted',
+      headers: { authorization: `Bearer ${adminToken}` },
+    })
+
+    expect(res.statusCode).toBe(200)
+    const body = res.json()
+    expect(body.event).not.toBeNull()
+    expect(body.event).toMatchObject({
+      id: expect.any(String),
+      name: expect.any(String),
+      eventDate: expect.any(String),
+      industryTags: expect.any(Array),
+    })
+    expect(body.daysUntil).toBeGreaterThanOrEqual(0)
+    expect(body.daysUntil).toBeLessThanOrEqual(14)
+    expect(body.uncontactedCount).toBeGreaterThan(0)
+  })
+
+  it('returns 401 without token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/events/upcoming-uncontacted',
+    })
+
+    expect(res.statusCode).toBe(401)
+    expect(res.json().error.code).toBe('UNAUTHORIZED')
+  })
+})

--- a/yorindo-api/src/tests/repositories.test.ts
+++ b/yorindo-api/src/tests/repositories.test.ts
@@ -189,6 +189,14 @@ describe('InMemoryEventRepository', () => {
     expect(typeof metrics.invited).toBe('number')
     expect(typeof metrics.conversionRate).toBe('number')
   })
+
+  it('getUpcomingUncontacted returns a qualifying event within 14 days', async () => {
+    const upcoming = await repo.getUpcomingUncontacted()
+    expect(upcoming).not.toBeNull()
+    expect(upcoming!.daysTillEvent).toBeGreaterThanOrEqual(0)
+    expect(upcoming!.daysTillEvent).toBeLessThanOrEqual(14)
+    expect(upcoming!.uncontactedCount).toBeGreaterThan(0)
+  })
 })
 
 // ─── Registration Repository ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `GET /api/events/upcoming-uncontacted` for the contacts page event banner
- return upcoming event info with `daysUntil`, `uncontactedCount`, and FE-friendly `industryTags`
- update in-memory event repository to select qualifying published/active events within 14 days
- document the endpoint in OpenAPI and allow nullable `event` in the response schema
- add route and repository tests for the upcoming-uncontacted flow

## Verification
- `npm test -- src/tests/events.routes.test.ts src/tests/repositories.test.ts`
- `npx tsc --noEmit`