### PR TITLE
Implement story 11.4 assigned events backend fix

### DIFF
--- a/yorindo-api/src/routes/users.routes.ts
+++ b/yorindo-api/src/routes/users.routes.ts
@@ -28,6 +28,8 @@ const UserEventParams = z.object({ id: z.string().min(1), eventId: z.string().mi
 const AssignEventBody = z.object({ eventId: z.string().min(1) })
 
 export const usersRoutes: FastifyPluginAsync = async (fastify) => {
+  const adminOnly = { preHandler: [requireAuth, requireAdmin] }
+
   fastify.get('/api/users/me/assigned-events', { preHandler: requireAuth }, async (request, reply) => {
     const payload = request.user as JwtPayload
     if (payload.role === 'admin') {
@@ -82,12 +84,8 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  // Apply roles logic to the users feature routes
-  fastify.addHook('preHandler', requireAuth)
-  fastify.addHook('preHandler', requireAdmin)
-
   // ─── POST /api/users ──────────────────────────────────────────────────────
-  fastify.post('/api/users', async (request, reply) => {
+  fastify.post('/api/users', adminOnly, async (request, reply) => {
     const result = CreateUserBody.safeParse(request.body)
     if (!result.success) {
       return reply.status(400).send({
@@ -137,7 +135,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   // ─── GET /api/users ───────────────────────────────────────────────────────
-  fastify.get('/api/users', async (request, reply) => {
+  fastify.get('/api/users', adminOnly, async (request, reply) => {
     const query = PaginationQuery.safeParse(request.query)
     if (!query.success) {
       return reply.status(400).send({
@@ -160,7 +158,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   // ─── PATCH /api/users/:id ─────────────────────────────────────────────────
-  fastify.patch('/api/users/:id', async (request, reply) => {
+  fastify.patch('/api/users/:id', adminOnly, async (request, reply) => {
     const paramsResult = UserIdParams.safeParse(request.params)
     if (!paramsResult.success) {
       return reply.status(400).send({
@@ -218,7 +216,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
   })
 
   // ─── DELETE /api/users/:id ────────────────────────────────────────────────
-  fastify.delete('/api/users/:id', async (request, reply) => {
+  fastify.delete('/api/users/:id', adminOnly, async (request, reply) => {
     const paramsResult = UserIdParams.safeParse(request.params)
     if (!paramsResult.success) {
       return reply.status(400).send({
@@ -261,7 +259,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(204).send()
   })
 
-  fastify.get('/api/users/:id/events', async (request, reply) => {
+  fastify.get('/api/users/:id/events', adminOnly, async (request, reply) => {
     const params = UserIdParams.safeParse(request.params)
     if (!params.success) {
       return reply.status(400).send({
@@ -300,7 +298,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  fastify.post('/api/users/:id/events', async (request, reply) => {
+  fastify.post('/api/users/:id/events', adminOnly, async (request, reply) => {
     const params = UserIdParams.safeParse(request.params)
     const body = AssignEventBody.safeParse(request.body)
     if (!params.success || !body.success) {
@@ -360,7 +358,7 @@ export const usersRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(201).send(responseBody)
   })
 
-  fastify.delete('/api/users/:id/events/:eventId', async (request, reply) => {
+  fastify.delete('/api/users/:id/events/:eventId', adminOnly, async (request, reply) => {
     const params = UserEventParams.safeParse(request.params)
     if (!params.success) {
       return reply.status(400).send({

--- a/yorindo-api/src/tests/users.routes.test.ts
+++ b/yorindo-api/src/tests/users.routes.test.ts
@@ -51,6 +51,42 @@ describe('Users API', () => {
     })
   })
 
+  describe('GET /api/users/me/assigned-events', () => {
+    it('returns only assigned events for staff', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/api/users/me/assigned-events',
+        headers: { Authorization: `Bearer ${getAuthToken('staff')}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.data).toHaveLength(6)
+      expect(body.data.map((event: { id: string }) => event.id)).toEqual([
+        SEED_EVENT_IDS[2],
+        SEED_EVENT_IDS[3],
+        SEED_EVENT_IDS[4],
+        SEED_EVENT_IDS[5],
+        SEED_EVENT_IDS[6],
+        SEED_EVENT_IDS[7],
+      ])
+    })
+
+    it('returns all events for admin', async () => {
+      const response = await fastify.inject({
+        method: 'GET',
+        url: '/api/users/me/assigned-events',
+        headers: { Authorization: `Bearer ${getAuthToken('admin')}` },
+      })
+
+      expect(response.statusCode).toBe(200)
+      const body = response.json()
+      expect(body.data).toHaveLength(12)
+      expect(body.data[0]).toHaveProperty('eventDate')
+      expect(body.data[0]).toHaveProperty('timezone')
+    })
+  })
+
   describe('POST /api/users', () => {
     it('creates a new user and an audit log', async () => {
       const response = await fastify.inject({


### PR DESCRIPTION
## Summary
- fix `/api/users/me/assigned-events` so staff can access assigned event data
- keep admin-only protection on user management routes
- add backend tests for staff and admin assigned-events responses
- backend inti Story 11.4 sebenarnya sudah ada, tetapi ada bug akses yang membuat staff mendapat `403` di route assigned events

## Verification
- `npm test -- src/tests/users.routes.test.ts src/tests/epic1-backend-contract.test.ts`
- `npx tsc --noEmit`