### PR TITLE
Implemetation story 3.14 contact API JWT enforcement

### DIFF
--- a/_bmad-output/implementation-artifacts/3-14-contact-api-jwt-enforcement.md
+++ b/_bmad-output/implementation-artifacts/3-14-contact-api-jwt-enforcement.md
@@ -1,0 +1,185 @@
+# Story 3.14: Contact API JWT Enforcement
+
+**Story ID:** 3.14
+**Story Key:** 3-14-contact-api-jwt-enforcement
+**Epic:** Epic 3 — Contact Database & Participant Intelligence
+**Phase:** Phase 2 (BE) — security hardening for internal contact APIs
+**Status:** review
+**Created:** 2026-04-02
+
+---
+
+## Story
+
+As an admin,
+I want all internal contact database endpoints to require JWT authentication and admin authorization,
+So that sensitive participant data and contact maintenance actions cannot be accessed publicly.
+
+> **Origin:** QA bug report on `story3-1-bugfix` found that multiple `/api/contacts*` endpoints still returned HTTP 200 without JWT.
+>
+> **Why this is a new story:** Story 2.1 already provides JWT auth and role middleware, but this issue is a gap enforcement problem in Epic 3 contact routes, not a missing auth foundation.
+
+---
+
+## Acceptance Criteria
+
+**AC1 — Unauthenticated access is blocked:**
+Given no `Authorization: Bearer <token>` header is sent,
+When any internal contact endpoint below is called,
+Then the API returns HTTP 401 with the standard error shape `{ error: { code, message, details } }`.
+
+**Affected endpoints in scope:**
+- `GET /api/contacts`
+- `GET /api/contacts/health`
+- `GET /api/contacts/facets`
+- `GET /api/contacts/industry-suggestions`
+- `GET /api/contacts/duplicates`
+- `POST /api/contacts/:id/merge`
+
+**AC2 — Non-admin access is blocked:**
+Given a valid JWT for a non-admin internal role such as `staff` or `viewer`,
+When any endpoint in scope is called,
+Then the API returns HTTP 403 with `{ error: { code: 'FORBIDDEN', ... } }`.
+
+**AC3 — Admin access still works:**
+Given a valid admin JWT,
+When `GET /api/contacts` is called with existing pagination, filter, and sorting params,
+Then the endpoint still returns HTTP 200 with the same contact list contract and existing behavior unchanged.
+
+**AC4 — Contact utility endpoints keep behavior for admin:**
+Given a valid admin JWT,
+When `GET /api/contacts/health`, `GET /api/contacts/facets`, `GET /api/contacts/industry-suggestions`, and `GET /api/contacts/duplicates` are called,
+Then each endpoint still returns HTTP 200 with its current response contract unchanged.
+
+**AC5 — Merge action is protected and preserved:**
+Given a valid admin JWT,
+When `POST /api/contacts/:id/merge` is called with a valid merge payload,
+Then the merge still succeeds with HTTP 200 and the duplicate pair state changes as before.
+
+**AC6 — Automated regression coverage exists:**
+Given the contact route test suite,
+When tests run,
+Then it covers unauthorized (`401`), forbidden (`403`), and successful admin (`200`) access for the contact routes in scope.
+
+---
+
+## Tasks / Subtasks
+
+- [x] **Task 1 — Audit contact route protection**
+  - [x] Confirm which `/api/contacts*` endpoints are currently missing auth/role guards
+  - [x] Reuse the existing auth middleware from Story 2.1 rather than introducing a new auth pattern
+
+- [x] **Task 2 — Enforce JWT + admin role on contact routes**
+  - [x] Apply `requireAuth` and `requireAdmin` to the internal contact list route
+  - [x] Apply the same guard to contact utility routes: health, facets, and industry suggestions
+  - [x] Apply the same guard to duplicate review and merge routes
+
+- [x] **Task 3 — Preserve admin behavior**
+  - [x] Verify existing query parsing, filtering, sorting, and pagination behavior for `GET /api/contacts` remains unchanged for admin
+  - [x] Verify duplicate merge flow still works for admin
+
+- [x] **Task 4 — Add regression tests**
+  - [x] Add unauthorized access tests for the routes in scope
+  - [x] Add forbidden access tests for `staff` and/or `viewer`
+  - [x] Keep or add one success-path admin test for each protected route group
+
+- [x] **Task 5 — Verify contract and type safety**
+  - [x] Run targeted route tests
+  - [x] Run TypeScript typecheck
+
+---
+
+## Dev Notes
+
+### Bug Summary
+
+QA confirmed that several `/api/contacts*` endpoints returned HTTP 200 without JWT. This is a security regression because the contact database is an internal admin workspace, not a public API surface.
+
+### Existing Auth Foundation
+
+Story 2.1 already introduced the required backend auth middleware and role helpers. Reuse the existing implementation in:
+
+- `yorindo-api/src/middleware/auth.ts`
+  - `requireAuth`
+  - `requireAdmin`
+  - `requireRoles(...)`
+
+Do not create a second auth mechanism for this story.
+
+### Route Scope
+
+Primary implementation target:
+
+- `yorindo-api/src/routes/contacts.routes.ts`
+
+The current contact routes include both the original Story 3.1 list endpoint and later Epic 3 support endpoints added by Stories 3.5–3.8. This story hardens the entire internal contact route group in one pass because the bug is route-level, not UI-level.
+
+### Role Policy for This Story
+
+Use the current Epic 3 policy:
+
+- `admin`: allowed
+- `staff`: forbidden
+- `viewer`: forbidden
+- unauthenticated/public: unauthorized
+
+This matches the original Epic 3 acceptance criteria for the contact database workspace.
+
+### Regression Risk
+
+The main risk is accidentally changing admin behavior while adding guards. The fix should be limited to route protection and related tests. Avoid changing DTO shape, filter logic, merge logic, or pagination behavior unless a test exposes an unrelated defect.
+
+### Suggested Files
+
+- `yorindo-api/src/routes/contacts.routes.ts`
+- `yorindo-api/src/tests/contacts.routes.test.ts`
+- `yorindo-api/openapi.yaml` if route security metadata needs to be made explicit
+
+### Verification
+
+Minimum verification expected:
+
+```bash
+cd yorindo-api
+npm test -- src/tests/contacts.routes.test.ts
+npx tsc --noEmit
+```
+
+If tests are grouped differently, include any repository or contract tests needed to cover merge flow and auth behavior.
+
+---
+
+## Dev Agent Record
+
+### Implementation Plan
+
+- Add admin-only protection to the internal contact route group
+- Add auth regression tests for unauthorized and forbidden access
+- Re-run existing admin success-path tests to ensure no behavioral regressions
+
+### Debug Log
+
+- Added a shared `adminOnly` preHandler config in `contacts.routes.ts` and applied it to the internal `/api/contacts*` routes that were previously public.
+- Updated contact route tests so all existing success-path checks use an admin JWT and added route-level `401`/`403` regression coverage.
+
+### Completion Notes
+
+- Internal contact APIs now require JWT + admin role, closing the public access gap reported by QA.
+- Existing admin list, facets, health, smart filter, duplicate review, and merge behavior remained unchanged after guard enforcement.
+- Verification passed with `npm test -- src/tests/contacts.routes.test.ts` and `npx tsc --noEmit`.
+
+---
+
+## File List
+
+- `yorindo-api/src/routes/contacts.routes.ts`
+- `yorindo-api/src/tests/contacts.routes.test.ts`
+
+---
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-04-02 | Story created for contact API JWT enforcement bugfix | Codex |
+| 2026-04-02 | Implemented admin-only JWT enforcement for internal contact APIs and added regression tests | Codex |

--- a/_bmad-output/implementation-artifacts/sprint-status.yaml
+++ b/_bmad-output/implementation-artifacts/sprint-status.yaml
@@ -1,5 +1,5 @@
 generated: 2026-03-19
-last_updated: 2026-03-28 (SCP-2026-03-28-A/B/C/D/E/F applied + AI_PROVIDER simplification + Epic 1 code review patches: cookie maxAge fix; CD tag trigger+DockerHub revert; scan 422 for invalid ticket; hard delete UserRepository; flagFilter URL sync; missingPhone filter fix; safePage pagination guard; audit log non-blocking; OpenAPI schema corrections + Epic 2 story 2-1 review patches: render-phase router fix; participant JwtPayload role; authStore eventKeys+setAuth; MSW login eventKeys+name+any-password; LoginForm→setAuth; refresh mock contract fix)
+last_updated: 2026-04-02 (implemented Story 3.14 contact API JWT enforcement)
 project: yorindo
 project_key: NOKEY
 tracking_system: file-system
@@ -98,6 +98,7 @@ development_status:
   3-11-eventbanner-pre-event-blast-shortcut: review
   3-12-contact-event-history-tab-in-sheet: review
   3-13-inline-blast-modal-contact-page-blast-composer: ready-for-dev
+  3-14-contact-api-jwt-enforcement: review
   epic-3-retrospective: optional
 
   # ─────────────────────────────────────────────

--- a/yorindo-api/src/routes/contacts.routes.ts
+++ b/yorindo-api/src/routes/contacts.routes.ts
@@ -282,7 +282,9 @@ function computeApprovalCompleteness(input: {
 }
 
 export const contactRoutes: FastifyPluginAsync = async (fastify) => {
-  fastify.get('/api/contacts/health', async (_request, reply) => {
+  const adminOnly = { preHandler: [requireAuth, requireAdmin] }
+
+  fastify.get('/api/contacts/health', adminOnly, async (_request, reply) => {
     const health = await contactRepository.countHealth()
 
     const responseBody = {
@@ -295,13 +297,13 @@ export const contactRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  fastify.get('/api/contacts/facets', async (_request, reply) => {
+  fastify.get('/api/contacts/facets', adminOnly, async (_request, reply) => {
     const responseBody = toFacetsDto(await contactRepository.findFacets())
     validateOpenApiResponse({ path: '/contacts/facets', method: 'get', status: 200, body: responseBody })
     return reply.status(200).send(responseBody)
   })
 
-  fastify.get('/api/contacts', async (request, reply) => {
+  fastify.get('/api/contacts', adminOnly, async (request, reply) => {
     const result = ContactsQuerySchema.safeParse(request.query)
     if (!result.success) {
       return reply.status(400).send({
@@ -356,7 +358,7 @@ export const contactRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  fastify.get('/api/contacts/industry-suggestions', async (request, reply) => {
+  fastify.get('/api/contacts/industry-suggestions', adminOnly, async (request, reply) => {
     const result = IndustrySuggestionsQuerySchema.safeParse(request.query)
     if (!result.success) {
       return reply.status(400).send({
@@ -401,7 +403,7 @@ export const contactRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  fastify.get('/api/contacts/duplicates', async (request, reply) => {
+  fastify.get('/api/contacts/duplicates', adminOnly, async (request, reply) => {
     const result = DuplicatesQuerySchema.safeParse(request.query)
     if (!result.success) {
       return reply.status(400).send({
@@ -433,7 +435,7 @@ export const contactRoutes: FastifyPluginAsync = async (fastify) => {
     return reply.status(200).send(responseBody)
   })
 
-  fastify.post('/api/contacts/:id/merge', async (request, reply) => {
+  fastify.post('/api/contacts/:id/merge', adminOnly, async (request, reply) => {
     const paramsResult = MergeParamsSchema.safeParse(request.params)
     const bodyResult = MergeBodySchema.safeParse(request.body)
 

--- a/yorindo-api/src/tests/contacts.routes.test.ts
+++ b/yorindo-api/src/tests/contacts.routes.test.ts
@@ -24,11 +24,56 @@ afterAll(async () => {
   await app.close()
 })
 
+describe('Contacts route auth guards', () => {
+  it('returns 401 for unauthenticated access to internal contact routes', async () => {
+    const responses = await Promise.all([
+      app.inject({ method: 'GET', url: '/api/contacts?page=1&pageSize=20' }),
+      app.inject({ method: 'GET', url: '/api/contacts/health' }),
+      app.inject({ method: 'GET', url: '/api/contacts/facets' }),
+      app.inject({ method: 'GET', url: '/api/contacts/industry-suggestions?q=teknologi' }),
+      app.inject({ method: 'GET', url: '/api/contacts/duplicates?page=1&pageSize=10' }),
+      app.inject({
+        method: 'POST',
+        url: '/api/contacts/cuid2contact000000000001/merge',
+        payload: { mergeIntoId: 'cuid2contact000000000001' },
+      }),
+    ])
+
+    for (const response of responses) {
+      expect(response.statusCode).toBe(401)
+      expect(response.json().error.code).toBe('UNAUTHORIZED')
+    }
+  })
+
+  it('returns 403 for staff access to internal contact routes', async () => {
+    const headers = { authorization: `Bearer ${getAuthToken('staff')}` }
+    const responses = await Promise.all([
+      app.inject({ method: 'GET', url: '/api/contacts?page=1&pageSize=20', headers }),
+      app.inject({ method: 'GET', url: '/api/contacts/health', headers }),
+      app.inject({ method: 'GET', url: '/api/contacts/facets', headers }),
+      app.inject({ method: 'GET', url: '/api/contacts/industry-suggestions?q=teknologi', headers }),
+      app.inject({ method: 'GET', url: '/api/contacts/duplicates?page=1&pageSize=10', headers }),
+      app.inject({
+        method: 'POST',
+        url: '/api/contacts/cuid2contact000000000001/merge',
+        headers,
+        payload: { mergeIntoId: 'cuid2contact000000000001' },
+      }),
+    ])
+
+    for (const response of responses) {
+      expect(response.statusCode).toBe(403)
+      expect(response.json().error.code).toBe('FORBIDDEN')
+    }
+  })
+})
+
 describe('GET /api/contacts/health', () => {
   it('returns contacts health counters', async () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/health',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -45,6 +90,7 @@ describe('GET /api/contacts/facets', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/facets',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -77,6 +123,7 @@ describe('GET /api/contacts', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=1&pageSize=20',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -91,6 +138,7 @@ describe('GET /api/contacts', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=1&pageSize=20&industry=teknologi',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -104,6 +152,7 @@ describe('GET /api/contacts', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=1&pageSize=20&companySize=medium',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -116,6 +165,7 @@ describe('GET /api/contacts', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=1&pageSize=5&sortBy=name&sortDir=asc',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -128,6 +178,7 @@ describe('GET /api/contacts', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=0&pageSize=20',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(400)
@@ -140,6 +191,7 @@ describe('GET /api/contacts/industry-suggestions', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/industry-suggestions?q=teknologi%20informasi',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -154,6 +206,7 @@ describe('GET /api/contacts/industry-suggestions', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/industry-suggestions?q=xyzabc',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -166,6 +219,7 @@ describe('GET /api/contacts/industry-suggestions', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/industry-suggestions?q=t',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -181,6 +235,7 @@ describe('Duplicate contacts routes', () => {
     const res = await app.inject({
       method: 'GET',
       url: '/api/contacts/duplicates?page=1&pageSize=3',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(200)
@@ -195,6 +250,7 @@ describe('Duplicate contacts routes', () => {
     const beforeRes = await app.inject({
       method: 'GET',
       url: '/api/contacts/duplicates?page=1&pageSize=10',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
     const beforeBody = beforeRes.json()
     const pair = beforeBody.data[0]
@@ -202,6 +258,7 @@ describe('Duplicate contacts routes', () => {
     const mergeRes = await app.inject({
       method: 'POST',
       url: `/api/contacts/${pair.primary.id}/merge`,
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
       payload: {
         mergeIntoId: pair.primary.id,
         fieldSelections: {
@@ -220,6 +277,7 @@ describe('Duplicate contacts routes', () => {
     const afterRes = await app.inject({
       method: 'GET',
       url: '/api/contacts/duplicates?page=1&pageSize=10',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
     const afterBody = afterRes.json()
     expect(afterBody.pagination.total).toBe(beforeBody.pagination.total - 1)
@@ -229,6 +287,7 @@ describe('Duplicate contacts routes', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/api/contacts/not-a-real-contact-id/merge',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
 
     expect(res.statusCode).toBe(404)
@@ -304,6 +363,7 @@ describe('Flagged records routes', () => {
     const contactsRes = await app.inject({
       method: 'GET',
       url: '/api/contacts?page=1&pageSize=100',
+      headers: { authorization: `Bearer ${getAuthToken('admin')}` },
     })
     expect(contactsRes.statusCode).toBe(200)
     expect(contactsRes.json().data.some((contact: { phone: string; name: string }) => (


### PR DESCRIPTION
## Summary
- fix the security gap in contact APIs where several internal `/api/contacts*` endpoints were still accessible without JWT
- apply the existing `requireAuth` and `requireAdmin` middleware from Story 2.1 to the relevant contact routes
- add regression coverage for `401` unauthenticated access and `403` non-admin access
- preserve existing admin success paths for contacts list, duplicate merge, and flagged records flows

## Verification
- `npm test -- src/tests/contacts.routes.test.ts`
- `npx tsc --noEmit`