### PR TITLE
fix: vendor creation fails with null id constraint violation

### DIFF
--- a/yorindo-api/src/repositories/postgres/VendorRepository.ts
+++ b/yorindo-api/src/repositories/postgres/VendorRepository.ts
@@ -2,6 +2,7 @@ import type { Pool, QueryResultRow } from 'pg'
 import type { IVendorRepository } from '../../interfaces/repositories/IVendorRepository.js'
 import type { Vendor, EntityId } from '../../types/domain.js'
 import { BasePostgresRepository } from './BasePostgresRepository.js'
+import { createId } from '@paralleldrive/cuid2'
 
 interface VendorRow extends QueryResultRow {
   id: string
@@ -60,10 +61,11 @@ export class PostgresVendorRepository
   }
 
   async create(data: Omit<Vendor, 'id' | 'createdAt' | 'updatedAt'>): Promise<Vendor> {
+    const id = createId()
     const { rows } = await this.query<VendorRow>(
-      `INSERT INTO vendors (name, contact_email, industry, logo_url, website, notes)
-       VALUES ($1,$2,$3,$4,$5,$6) RETURNING *`,
-      [data.name, data.contactEmail, data.industry, data.logoUrl, data.website, data.notes],
+      `INSERT INTO vendors (id, name, contact_email, industry, logo_url, website, notes)
+       VALUES ($1,$2,$3,$4,$5,$6,$7) RETURNING *`,
+      [id, data.name, data.contactEmail, data.industry, data.logoUrl, data.website, data.notes],
     )
     return this.mapRow(rows[0]!)
   }

--- a/yorindo-app/src/hooks/useVendors.ts
+++ b/yorindo-app/src/hooks/useVendors.ts
@@ -1,5 +1,7 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 import type { Vendor, CreateVendorBody, PaginatedResponse } from '@/types/api'
+import { getUserFriendlyError } from '@/lib/error-messages'
 
 async function fetchVendors(): Promise<PaginatedResponse<Vendor>> {
   const res = await fetch('/api/vendors?pageSize=20')
@@ -13,7 +15,10 @@ async function createVendor(body: CreateVendorBody): Promise<Vendor> {
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error('Failed to create vendor')
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}))
+    throw new Error(errorData.error?.message ?? 'Failed to create vendor')
+  }
   return res.json()
 }
 
@@ -23,7 +28,10 @@ async function updateVendor(id: string, body: Partial<CreateVendorBody>): Promis
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body),
   })
-  if (!res.ok) throw new Error('Failed to update vendor')
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}))
+    throw new Error(errorData.error?.message ?? 'Failed to update vendor')
+  }
   return res.json()
 }
 
@@ -49,6 +57,10 @@ export function useCreateVendor() {
     mutationFn: createVendor,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['vendors'] })
+      toast.success('Vendor berhasil ditambahkan')
+    },
+    onError: (error) => {
+      toast.error(getUserFriendlyError(error))
     },
   })
 }
@@ -59,6 +71,10 @@ export function useUpdateVendor(id: string) {
     mutationFn: (body: Partial<CreateVendorBody>) => updateVendor(id, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['vendors'] })
+      toast.success('Vendor berhasil diperbarui')
+    },
+    onError: (error) => {
+      toast.error(getUserFriendlyError(error))
     },
   })
 }
@@ -69,6 +85,10 @@ export function useDeleteVendor() {
     mutationFn: deleteVendor,
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['vendors'] })
+      toast.success('Vendor berhasil dihapus')
+    },
+    onError: (error) => {
+      toast.error(getUserFriendlyError(error))
     },
   })
 }


### PR DESCRIPTION
- PostgresVendorRepository.create() now generates CUID2 ID before insert
- Added createId import from @paralleldrive/cuid2
- useVendors hooks now use getUserFriendlyError for consistent error messages
- Added toast notifications for vendor CRUD operations:
  - Create: 'Vendor berhasil ditambahkan'
  - Update: 'Vendor berhasil diperbarui'
  - Delete: 'Vendor berhasil dihapus'
- Error responses now properly parsed from API before throwing
- TypeScript clean